### PR TITLE
Store the OAUTH2 id_token in the id_token extra data.

### DIFF
--- a/lib/omniauth/strategies/okta.rb
+++ b/lib/omniauth/strategies/okta.rb
@@ -40,10 +40,10 @@ module OmniAuth
           h[:raw_info] = raw_info unless skip_info?
 
           if access_token
-            h[:id_token] = access_token.token
+            h[:id_token] = oauth2_access_token['id_token']
 
-            if !options[:skip_jwt] && !access_token.token.nil?
-              h[:id_info] = validated_token(access_token.token)
+            if !options[:skip_jwt] && !h[:id_token].nil?
+              h[:id_info] = validated_token(h[:id_token])
             end
           end
         end


### PR DESCRIPTION
We needed to implement the logout flow for OKTA. Docs here https://developer.okta.com/docs/reference/api/oidc/#logout. It is not super clear but the  `id_token_hint` param is expected to be the `id_token` provided by OKTA in response the `/token` request.

It turns out that the `id_token` and `id_info` field in `extra` where being populated from the access_token instead of the id token. The attached change fixes that to return the `id_token`.

I kept the nil check but the token should always be present in the response of https://developer.okta.com/docs/reference/api/oidc/#token as long we request the openid scope. 