### PR TITLE
Store ID token not access token for ID token in extra info

### DIFF
--- a/lib/omniauth/strategies/okta.rb
+++ b/lib/omniauth/strategies/okta.rb
@@ -39,11 +39,11 @@ module OmniAuth
         {}.tap do |h|
           h[:raw_info] = raw_info unless skip_info?
 
-          if access_token
-            h[:id_token] = access_token.token
+          if oauth2_access_token
+            h[:id_token] = oauth2_access_token['id_token']
 
-            if !options[:skip_jwt] && !access_token.token.nil?
-              h[:id_info] = validated_token(access_token.token)
+            if !options[:skip_jwt] && !h[:id_token].nil?
+              h[:id_info] = validated_token(h[:id_token])
             end
           end
         end

--- a/spec/omniauth/strategies/okta_spec.rb
+++ b/spec/omniauth/strategies/okta_spec.rb
@@ -70,6 +70,8 @@ describe OmniAuth::Strategies::Okta do
   end
 
   describe 'extra' do
+    subject { described_class.new('app', skip_jwt: true) }
+
     before :each do
       allow(subject).to receive(:raw_info) { { :foo => 'bar' } }
       allow(subject).to receive(:access_token)
@@ -79,12 +81,24 @@ describe OmniAuth::Strategies::Okta do
                                             refresh_token: 'token',
                                             expires_in:    0,
                                             expires_at:    0))
+      allow(subject).to receive(:oauth2_access_token)
+                        .and_return(
+                          ::OAuth2::AccessToken.new(
+                            'client',
+                            nil,
+                            refresh_token: 'token',
+                            expires_in:    0,
+                            expires_at:    0,
+                            'id_token' => 'id_token',
+                          ),
+                        )
     end
 
     it { expect(subject.extra[:raw_info]).to eq({ :foo => 'bar' }) }
-  end
 
-  describe 'id_token' do
+    describe 'id_token' do
+      it { expect(subject.extra[:id_token]).to eq('id_token') }
+    end
   end
 
   describe 'raw_info' do


### PR DESCRIPTION
Followup to https://github.com/omniauth/omniauth-okta/pull/17 which replaces the access token with the ID token in the extra info.

This PR slightly changes the solution and includes a spec.

